### PR TITLE
Get rid of non-hyperlink link + update some FAQ on Tech Support + general typo

### DIFF
--- a/docs/anki.md
+++ b/docs/anki.md
@@ -134,8 +134,7 @@ Below are some troubleshooting tips you can try if you are unable to create new 
 
 Using the `Generate Anki Notes (Experimental)...` feature in the settings page it is possible to easily generate and export large amounts of Anki cards.
 
-> [!WARNING]
-> This feature is experimental!
+!!! warning This feature is experimental!
 
 First, get a newline separated list of terms. For example:
 

--- a/docs/dictionaries.md
+++ b/docs/dictionaries.md
@@ -19,6 +19,11 @@ Be aware that non-English dictionaries generally contain fewer entries than thei
 
     If you can't find suitable Yomitan dictionaries, feel free to Google for dictionaries in your specific language or ask your fellow community members.
 
+#### Multilingual
+
+  - [KTY](https://github.com/yomidevs/kaikki-to-yomitan/blob/master/downloads.md) - Wiktionaries in various languages converted to Yomitan format.
+  - [Wikipedia for Yomitan](https://github.com/MarvNC/wikipedia-yomitan) - All of Wikipedia in Yomitan for various languages.
+
 #### Japanese
 
 - [Jitendex](https://github.com/stephenmk/Jitendex) - An improved version of JMdict for Yomitan. It features better formatting and some other improvements, and is actively being improved by its author.
@@ -33,11 +38,6 @@ Be aware that non-English dictionaries generally contain fewer entries than thei
     Yomitan supports dictionaries in the esoteric but popular [EPWING](https://ja.wikipedia.org/wiki/EPWING) format. They were often utilized in portable electronic dictionaries. These dictionaries are often sought after by language learners for their correctness and excellent coverage of the Japanese language.
 
     Unfortunately, as most of the dictionaries released in this format are proprietary, you will need to procure these dictionaries yourself and import them using [Yomitan Import](https://github.com/yomidevs/yomitan-import). Check the project page for additional details.
-
-#### Multilingual
-
-  - [KTY](https://github.com/yomidevs/kaikki-to-yomitan/blob/master/downloads.md) - Wiktionaries in various languages converted to Yomitan format.
-  - [Wikipedia for Yomitan](https://github.com/MarvNC/wikipedia-yomitan) - All of Wikipedia in Yomitan for various languages.
 
 #### Korean
 

--- a/docs/dictionaries.md
+++ b/docs/dictionaries.md
@@ -5,8 +5,6 @@ hide:
 ---
 
 
-## Dictionaries
-
 You must download and import the dictionaries you wish to use in order to enable Yomitan definition lookups.
 
 There are several free dictionaries available for Yomitan, some of them with glossaries available in different languages.

--- a/docs/dictionaries.md
+++ b/docs/dictionaries.md
@@ -15,6 +15,10 @@ Be aware that non-English dictionaries generally contain fewer entries than thei
 
 ### Recommended Dictionaries
 
+!!! note
+
+    If you can't find suitable Yomitan dictionaries, feel free to Google for dictionaries in your specific language or ask your fellow community members.
+
 #### Japanese
 
 - [Jitendex](https://github.com/stephenmk/Jitendex) - An improved version of JMdict for Yomitan. It features better formatting and some other improvements, and is actively being improved by its author.
@@ -30,29 +34,22 @@ Be aware that non-English dictionaries generally contain fewer entries than thei
 
     Unfortunately, as most of the dictionaries released in this format are proprietary, you will need to procure these dictionaries yourself and import them using [Yomitan Import](https://github.com/yomidevs/yomitan-import). Check the project page for additional details.
 
-
-#### Other Languages
-
-!!! note
-
-    If you can't find suitable Yomitan dictionaries, feel free to Google for dictionaries in your specific language or ask your fellow community members
-
-**Multilingual**
+#### Multilingual
 
   - [KTY](https://github.com/yomidevs/kaikki-to-yomitan/blob/master/downloads.md) - Wiktionaries in various languages converted to Yomitan format.
   - [Wikipedia for Yomitan](https://github.com/MarvNC/wikipedia-yomitan) - All of Wikipedia in Yomitan for various languages.
 
-**Korean**
+#### Korean
 
   - [KRDICT/STDICT](https://github.com/Lyroxide/yomitan-ko-dic/releases) - Korean dictionaries for Yomitan.
 
-**Cantonese**
-
-  - [words.hk for Yomitan](https://github.com/MarvNC/wordshk-yomitan) - A free Cantonese-English and Cantonese-Cantonese dictionary for Yomitan.
-
-**Mandarin**
+#### Mandarin
 
   - [CC-CEDICT for Yomitan](https://github.com/MarvNC/cc-cedict-yomitan) - A free Chinese-English dictionary for Yomitan.
+
+#### Cantonese
+
+  - [words.hk for Yomitan](https://github.com/MarvNC/wordshk-yomitan) - A free Cantonese-English and Cantonese-Cantonese dictionary for Yomitan.
 
 ### Bulk Importing Dictionaries
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ hide:
 
 This introduction will help you quickly familiarize yourself with the basics and set you up for a smooth language learning experience.
 
-!!! note "Migrating from Yomichan? Learn how to migrate to Yomitan [here](yomichan-migration.md)"
+!!! note "Migrating from Yomichan? Learn how to migrate to Yomitan [here](yomichan-migration.md)."
 ---
 
 ## Installation

--- a/docs/support.md
+++ b/docs/support.md
@@ -11,7 +11,7 @@ Having trouble with Yomitan? If you don't find your answers here, feel free to r
 
 We have an active community of users and collaborators on our discord server.
 
-[![](https://img.shields.io/discord/308323056592486420?style=for-the-badge&label=Discord%20Chat&color=bc00ff)](https://discord.gg/eCKjNuXW)
+[![](https://img.shields.io/discord/308323056592486420?style=for-the-badge&label=Discord%20Chat&color=bc00ff)](https://discord.gg/YkQrXW6TXF)
 
 
 ## Github

--- a/docs/support.md
+++ b/docs/support.md
@@ -55,8 +55,7 @@ experience.
 **Is it possible to use Yomitan with files saved locally on my computer with Chrome?**
 
 In order to use Yomitan with local files in Chrome, you must first tick the _Allow access to file URLs_ checkbox
-for Yomitan on the extensions page. Due to the restrictions placed on browser addons in the WebExtensions model, it
-will likely never be possible to use Yomitan with PDF files.
+for Yomitan on the extensions page. In addition, you may use the [Yomitan PDF Viewer](https://yomitan.wiki/yomitan-pdf-viewer/web/) to view and scan PDF files that are on your local machine.
 
 **Is it possible to delete individual dictionaries without purging the database?**
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -16,7 +16,7 @@ We have an active community of users and collaborators on our discord server.
 
 ## Github
 
-You can [file an issue in our github repository here](https://github.com/yomidevs/yomitan/issues/new/choose) and provide any context that could help us help you resolve your issue.
+You can [file an issue on our GitHub repository](https://github.com/yomidevs/yomitan/issues/new/choose) and provide any context that could help us assist with your issue.
 
 ## Frequently Asked Questions
 

--- a/docs/tools-resources.md
+++ b/docs/tools-resources.md
@@ -30,7 +30,7 @@ A minimal e-book reader that loads HTMLZ, Plain Text and EPUB files. Supports of
 
 An ebook manager and reader with wider support of file formats. No support on mobile.
 
-#### [PDF Reader](yomitan-pdf-viewer/index.html)
+#### [Yomitan PDF Reader](yomitan-pdf-viewer/index.html)
 A tool to read and scan PDFs in your browser with Yomitan.
 
 ### Tooling

--- a/docs/tools-resources.md
+++ b/docs/tools-resources.md
@@ -31,7 +31,7 @@ A minimal e-book reader that loads HTMLZ, Plain Text and EPUB files. Supports of
 An ebook manager and reader with wider support of file formats. No support on mobile.
 
 #### [PDF Reader](yomitan-pdf-viewer/index.html)
-Reading PDF's in your browser that is Yomitan-scannable
+A tool to read and scan PDFs in your browser with Yomitan.
 
 ### Tooling
 

--- a/docs/tools-resources.md
+++ b/docs/tools-resources.md
@@ -26,7 +26,7 @@ Readers allow reading books and text on your browser which makes the text you re
 
 A minimal e-book reader that loads HTMLZ, Plain Text and EPUB files. Supports offline mode that makes this ideal for mobile and e-readers. This is the recommendation for Japanese learners.
 
-### [Koodo Reader](https://web.koodoreader.com/)
+#### [Koodo Reader](https://web.koodoreader.com/)
 
 An ebook manager and reader with wider support of file formats. No support on mobile.
 

--- a/docs/yomichan-migration.md
+++ b/docs/yomichan-migration.md
@@ -12,8 +12,7 @@ If you are an existing user of Yomichan, you can export your dictionary collecti
 
 You can export your settings from Yomichan's Settings page. Go to the `Backup` section and click on `Export Settings`.
 
-Yomichan doesn't have first-class support to export the dictionary collection. Please follow the instructions provided in the following link to export your data:
-https://github.com/yomidevs/yomichan-data-exporter#steps-to-export-the-data
+Unfortunately, Yomichan doesn't have first-class support to export the dictionary collection. Please follow [these](https://github.com/yomidevs/yomichan-data-exporter#steps-to-export-the-data) instructions to export your data.
 
 You can then import the exported files into Yomitan from the `Backup` section of the `Settings` page. Please see [the section on importing dictionaries](#importing-dictionaries) further below for more explicit steps.
 

--- a/docs/yomichan-migration.md
+++ b/docs/yomichan-migration.md
@@ -12,7 +12,7 @@ If you are an existing user of Yomichan, you can export your dictionary collecti
 
 You can export your settings from Yomichan's Settings page. Go to the `Backup` section and click on `Export Settings`.
 
-Unfortunately, Yomichan doesn't have first-class support to export the dictionary collection. Please follow [these](https://github.com/yomidevs/yomichan-data-exporter#steps-to-export-the-data) instructions to export your data.
+Yomichan doesn't have first-class support to export the dictionary collection. Please follow [these](https://github.com/yomidevs/yomichan-data-exporter#steps-to-export-the-data) instructions to export your data.
 
 You can then import the exported files into Yomitan from the `Backup` section of the `Settings` page. Please see [the section on importing dictionaries](#importing-dictionaries) further below for more explicit steps.
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/90580787-e69f-495b-905f-f236102fbe9a)

It's not clickable on the website so I just put it into an embedded link in the text

Someone should check the ones I did on dictionary page because I'm not sure if it's the best format idk